### PR TITLE
Removed Bandit from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdk-klayers"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = ["Keith Rozario <keithjosephrozario@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,6 @@ readme = "README.md"
 python = "^3.8"
 aws-cdk-lib = "^2.137.0"
 requests = "^2.31.0"
-bandit = {extras = ["baseline"], version = "^1.7.8"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Removed Bandit from dependency. Only needed for build and not install.

